### PR TITLE
Fix span linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
 /Cargo.lock
 
+.vscode
+
 tmp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ doc-comment = "0.3.3"
 futures = "0.3.29"
 tokio = { version = "1.28.1", features = ["rt", "macros", "test-util"] }
 tokio-test = "0.4.3"
+tracing-capture = { git = "https://github.com/ThomWright/tracing-toolbox.git", branch = "support-follows-from" }
+tracing-subscriber = "0.3.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ doc-comment = "0.3.3"
 futures = "0.3.29"
 tokio = { version = "1.28.1", features = ["rt", "macros", "test-util"] }
 tokio-test = "0.4.3"
-tracing-capture = { git = "https://github.com/ThomWright/tracing-toolbox.git", branch = "support-follows-from" }
+tracing-capture = "0.2.0-beta.1"
 tracing-subscriber = "0.3.18"

--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, hash::Hash, sync::Arc};
 
 use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot};
-use tracing::Span;
+use tracing::{span, Level, Span};
 
 use crate::{
     batch::BatchItem,
@@ -71,7 +71,7 @@ where
     /// Add an item to the batch and await the result.
     pub async fn add(&self, key: K, input: I) -> Result<O, E> {
         // Record the span ID so we can link the shared processing span.
-        let span_id = Span::current().id();
+        let requesting_span = Span::current().clone();
 
         let (tx, rx) = oneshot::channel();
         self.item_tx
@@ -79,11 +79,39 @@ where
                 key,
                 input,
                 tx,
-                span_id,
+                requesting_span,
             })
             .await?;
 
-        rx.await?
+        let (output, batch_span) = rx.await?;
+
+        {
+            let link_back_span = span!(Level::INFO, "batch finished");
+            if let Some(span) = batch_span {
+                // WARNING: It's very important that we don't drop the span until _after_
+                // follows_from().
+                //
+                // If we did e.g. `.follows_from(span)` then the span would get converted into an ID
+                // and dropped. Any attempt to look up the span by ID _inside_ follows_from() would
+                // then panic, because the span will have been closed and no longer exist.
+                //
+                // Don't ask me how long this took me to debug.
+                link_back_span.follows_from(span.id());
+                link_back_span.in_scope(|| {
+                    // Do nothing. This span is just here to work around a Honeycomb limitation:
+                    //
+                    // If the batch span is linked to a parent span like so:
+                    //
+                    // parent_span_1 <-link- batch_span
+                    //
+                    // then in Honeycomb, the link is only shown on the batch span. It it not possible
+                    // to click through to the batch span from the parent.
+                    //
+                    // So, here we link back to the batch to make this easier.
+                });
+            }
+        }
+        output
     }
 }
 

--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -96,7 +96,7 @@ where
                 // then panic, because the span will have been closed and no longer exist.
                 //
                 // Don't ask me how long this took me to debug.
-                link_back_span.follows_from(span.id());
+                link_back_span.follows_from(&span);
                 link_back_span.in_scope(|| {
                     // Do nothing. This span is just here to work around a Honeycomb limitation:
                     //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,5 +113,23 @@ mod test {
             2,
             "should follow from both handler spans"
         );
+
+        let link_back_spans: Vec<_> = storage
+            .all_spans()
+            .filter(|span| span.metadata().name().contains("batch finished"))
+            .collect();
+        assert_eq!(
+            link_back_spans.len(),
+            2,
+            "should be two spans for linking back to the process span"
+        );
+
+        for span in link_back_spans {
+            assert_eq!(
+                span.follows_from().len(),
+                1,
+                "should follow from the process span"
+            );
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,92 @@ mod worker;
 pub use batcher::{Batcher, Processor};
 pub use error::BatchError;
 pub use policies::{BatchingPolicy, Limits, OnFull};
+
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use tokio::join;
+    use tracing::{span, Instrument};
+
+    use crate::{Batcher, BatchingPolicy, Limits, Processor};
+
+    #[derive(Debug, Clone)]
+    pub struct SimpleBatchProcessor(pub Duration);
+
+    #[async_trait]
+    impl Processor<String, String, String> for SimpleBatchProcessor {
+        async fn process(
+            &self,
+            key: String,
+            inputs: impl Iterator<Item = String> + Send,
+        ) -> Result<Vec<String>, String> {
+            tokio::time::sleep(self.0).await;
+            Ok(inputs.map(|s| s + " processed for " + &key).collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tracing() {
+        use tracing::Level;
+        use tracing_capture::{CaptureLayer, SharedStorage};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let subscriber = tracing_subscriber::fmt()
+            .pretty()
+            .with_max_level(Level::INFO)
+            .finish();
+        // Add the capturing layer.
+        let storage = SharedStorage::default();
+        let subscriber = subscriber.with(CaptureLayer::new(&storage));
+
+        // Capture tracing information.
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let batcher = Batcher::new(
+            SimpleBatchProcessor(Duration::ZERO),
+            Limits::default().max_batch_size(2),
+            BatchingPolicy::Size,
+        );
+
+        let h1 = {
+            tokio_test::task::spawn({
+                let span = span!(Level::INFO, "test_handler_span1");
+
+                batcher
+                    .add("A".to_string(), "1".to_string())
+                    .instrument(span)
+            })
+        };
+        let h2 = {
+            tokio_test::task::spawn({
+                let span = span!(Level::INFO, "test_handler_span2");
+
+                batcher
+                    .add("A".to_string(), "2".to_string())
+                    .instrument(span)
+            })
+        };
+
+        let (_o1, _o2) = join!(h1, h2);
+
+        let storage = storage.lock();
+
+        let process_span: Vec<_> = storage
+            .all_spans()
+            .filter(|span| span.metadata().name().contains("process batch"))
+            .collect();
+        assert_eq!(
+            process_span.len(),
+            1,
+            "should be a single span for processing the batch"
+        );
+
+        assert_eq!(
+            process_span.first().unwrap().follows_from().len(),
+            2,
+            "should follow from both handler spans"
+        );
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,35 +1,12 @@
-use std::{marker::Send, time::Duration};
+use std::time::Duration;
 
-use async_trait::async_trait;
-use batch_aint_one::{Batcher, BatchingPolicy, Limits, OnFull, Processor};
+use batch_aint_one::{Batcher, BatchingPolicy, Limits, OnFull};
 use futures::future::join_all;
 use tokio::{join, time::Instant};
-// use tokio_test::assert_elapsed;
 
-#[derive(Debug, Clone)]
-struct SimpleBatchProcessor(Duration);
+use crate::types::SimpleBatchProcessor;
 
-#[async_trait]
-impl Processor<String, String, String> for SimpleBatchProcessor {
-    async fn process(
-        &self,
-        key: String,
-        inputs: impl Iterator<Item = String> + Send,
-    ) -> Result<Vec<String>, String> {
-        tokio::time::sleep(self.0).await;
-        Ok(inputs.map(|s| s + " processed for " + &key).collect())
-    }
-}
-
-struct NotCloneable {}
-type Cloneable = Batcher<String, NotCloneable, NotCloneable>;
-
-/// A [Batcher] should be cloneable, even when the `I`s and `O`s are not.
-#[derive(Clone)]
-#[allow(unused)]
-struct CanDeriveClone {
-    batcher: Cloneable,
-}
+mod types;
 
 #[tokio::test]
 async fn strategy_size() {

--- a/tests/types/mod.rs
+++ b/tests/types/mod.rs
@@ -1,0 +1,29 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use batch_aint_one::{Processor, Batcher};
+
+#[derive(Debug, Clone)]
+pub struct SimpleBatchProcessor(pub Duration);
+
+#[async_trait]
+impl Processor<String, String, String> for SimpleBatchProcessor {
+    async fn process(
+        &self,
+        key: String,
+        inputs: impl Iterator<Item = String> + Send,
+    ) -> Result<Vec<String>, String> {
+        tokio::time::sleep(self.0).await;
+        Ok(inputs.map(|s| s + " processed for " + &key).collect())
+    }
+}
+
+struct NotCloneable {}
+type Cloneable = Batcher<String, NotCloneable, NotCloneable>;
+
+/// A [Batcher] should be cloneable, even when the `I`s and `O`s are not.
+#[derive(Clone)]
+#[allow(unused)]
+struct CanDeriveClone {
+    batcher: Cloneable,
+}

--- a/tests/types/mod.rs
+++ b/tests/types/mod.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use batch_aint_one::{Processor, Batcher};
+use batch_aint_one::{Batcher, Processor};
 
 #[derive(Debug, Clone)]
 pub struct SimpleBatchProcessor(pub Duration);


### PR DESCRIPTION
This took me quite a number of hours with the debugger to figure out.

The key parts are:

- Spans can be cloned. Much like `Arc`, they have a reference count.
- When a span gets dropped, an attempt will be made to close it. It will only close it if the ref count is zero.
- Closing a span removes it from the Registry.
- If you try to call `span_a.follows_from(span_b_id)` after span B has been closed, it will panic. Therefore, a `Span` with that ID must still be in scope.
- If you call `span_a.follows_from(span_b)` then span B will be consumed (and hence dropped) and converted into an ID before being passed to the function. This ID will no longer refer to a valid span in the Registry.

The following both work:

- Passing by reference: `span_a.follows_from(&span_b)`
- Passing just the ID, keeping the span alive: `span_a.follows_from(span_b.id())`