### PR TITLE
Remove `async_trait`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "batch-aint-one"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Thom Wright <dev@thomwright.co.uk>"]
 description = """
@@ -15,7 +15,6 @@ categories = ["concurrency"]
 license = "MIT"
 
 [dependencies]
-async-trait = "0.1"
 thiserror = "2"
 tokio = { version = "1.33", features = [
   "sync",

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ With batching, we can improve the throughput. Acquiring/releasing the lock and b
 ```rust
 use std::{time::Duration, marker::Send, sync::Arc};
 
-use async_trait::async_trait;
 use batch_aint_one::{Batcher, BatchingPolicy, Limits, Processor};
 
 /// A simple processor which just sleeps then returns a mapped version
@@ -54,7 +53,6 @@ use batch_aint_one::{Batcher, BatchingPolicy, Limits, Processor};
 #[derive(Debug, Clone)]
 struct SleepyBatchProcessor;
 
-#[async_trait]
 impl Processor<String, String, String> for SleepyBatchProcessor {
     async fn process(
         &self,

--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -1,6 +1,5 @@
-use std::{fmt::Display, hash::Hash, sync::Arc};
+use std::{fmt::Display, future::Future, hash::Hash, sync::Arc};
 
-use async_trait::async_trait;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{span, Level, Span};
 
@@ -32,7 +31,6 @@ where
 }
 
 /// Process a batch of inputs for a given key.
-#[async_trait]
 pub trait Processor<K, I, O = (), E = String>
 where
     E: Display,
@@ -41,11 +39,11 @@ where
     ///
     /// The order of the outputs in the returned `Vec` must be the same as the order of the inputs
     /// in the given iterator.
-    async fn process(
+    fn process(
         &self,
         key: K,
         inputs: impl Iterator<Item = I> + Send,
-    ) -> std::result::Result<Vec<O>, E>;
+    ) -> impl Future<Output = std::result::Result<Vec<O>, E>> + Send;
 }
 
 impl<K, I, O, E> Batcher<K, I, O, E>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ pub use policies::{BatchingPolicy, Limits, OnFull};
 mod tests {
     use std::time::Duration;
 
-    use async_trait::async_trait;
     use tokio::join;
     use tracing::{span, Instrument};
 
@@ -46,7 +45,6 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct SimpleBatchProcessor(pub Duration);
 
-    #[async_trait]
     impl Processor<String, String, String> for SimpleBatchProcessor {
         async fn process(
             &self,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -183,7 +183,6 @@ impl Drop for WorkerHandle {
 
 #[cfg(test)]
 mod test {
-    use async_trait::async_trait;
     use tokio::sync::oneshot;
     use tracing::Span;
 
@@ -192,7 +191,6 @@ mod test {
     #[derive(Debug, Clone)]
     struct SimpleBatchProcessor;
 
-    #[async_trait]
     impl Processor<String, String, String> for SimpleBatchProcessor {
         async fn process(
             &self,

--- a/tests/types/mod.rs
+++ b/tests/types/mod.rs
@@ -1,12 +1,10 @@
 use std::time::Duration;
 
-use async_trait::async_trait;
 use batch_aint_one::{Batcher, Processor};
 
 #[derive(Debug, Clone)]
 pub struct SimpleBatchProcessor(pub Duration);
 
-#[async_trait]
 impl Processor<String, String, String> for SimpleBatchProcessor {
     async fn process(
         &self,


### PR DESCRIPTION
Since rust has support for async funtions in traits now, this is just better, especially for diagnostics