### PR TITLE
Implement resource acquisition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.33", features = [
 tracing = "0.1"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 doc-comment = "0.3.3"
 futures = "0.3.29"
 tokio = { version = "1.28.1", features = ["rt", "macros", "test-util"] }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ struct SleepyBatchProcessor;
 
 impl
     Processor<
-        /* key */ String,
+        /* keys */ String,
         /* inputs */ String,
         /* outputs */ String,
         /* errors */ String,

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ impl
     > for SleepyBatchProcessor
 {
     // Acquire some resources
-    async fn acquire_resources(&self, key: String) -> String {
-        "Some resources for: ".to_string() + &key
+    async fn acquire_resources(&self, key: String) -> Result<String, String> {
+        Ok("Some resources for: ".to_string() + &key)
     }
 
     async fn process(
@@ -136,7 +136,11 @@ This depends on the batching policy used. `BatchingPolicy::Immediate` optimises 
   - [x] Why – motivating example
   - [x] Code examples
 - [x] Tracing/logging
-- [ ] Metrics?
+- [x] Resource acquisition
+- [x] Record keys as span attributes
+- [ ] Return batch metadata
+- [ ] Allow app to await worker task
+- [ ] Metrics
 
 ## Further reading
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ With batching, we can improve the throughput. Acquiring/releasing the lock and b
 ## Example
 
 ```rust
-use std::{time::Duration, marker::Send, sync::Arc};
+
+use std::{marker::Send, sync::Arc, time::Duration};
 
 use batch_aint_one::{Batcher, BatchingPolicy, Limits, Processor};
 
@@ -53,11 +54,25 @@ use batch_aint_one::{Batcher, BatchingPolicy, Limits, Processor};
 #[derive(Debug, Clone)]
 struct SleepyBatchProcessor;
 
-impl Processor<String, String, String> for SleepyBatchProcessor {
+impl
+    Processor<
+        /* key */ String,
+        /* inputs */ String,
+        /* outputs */ String,
+        /* errors */ String,
+        /* resources */ String,
+    > for SleepyBatchProcessor
+{
+    // Acquire some resources
+    async fn acquire_resources(&self, key: String) -> String {
+        "Some resources for: ".to_string() + &key
+    }
+
     async fn process(
         &self,
         key: String,
         inputs: impl Iterator<Item = String> + Send,
+        _resources: String,
     ) -> Result<Vec<String>, String> {
         tokio::time::sleep(Duration::from_millis(10)).await;
         // In this example:
@@ -67,40 +82,44 @@ impl Processor<String, String, String> for SleepyBatchProcessor {
     }
 }
 
-tokio_test::block_on(async {
-    // Create a new batcher.
-    // Put it in an Arc so we can share it between handlers.
-    let batcher = Arc::new(Batcher::new(
-        // This will process items in a background worker task.
-        SleepyBatchProcessor,
+fn example() {
+    tokio_test::block_on(async {
+        // Create a new batcher.
+        // Put it in an Arc so we can share it between handlers.
+        let batcher = Arc::new(Batcher::new(
+            // This will process items in a background worker task.
+            SleepyBatchProcessor,
+            // Set some limits.
+            Limits::default().max_batch_size(2).max_key_concurrency(1),
+            // Process a batch when it reaches the max_batch_size.
+            BatchingPolicy::Size,
+        ));
 
-        // Set some limits.
-        Limits::default()
-          .max_batch_size(2)
-          .max_key_concurrency(1),
+        // Request handler 1
+        let batcher1 = batcher.clone();
+        tokio::spawn(async move {
+            // Add an item to be processed and wait for the result.
+            let output = batcher1
+                .add("Key A".to_string(), "Item 1".to_string())
+                .await
+                .unwrap();
 
-        // Process a batch when it reaches the max_batch_size.
-        BatchingPolicy::Size,
-    ));
+            assert_eq!("Item 1 processed for Key A".to_string(), output);
+        });
 
-    // Request handler 1
-    let batcher1 = batcher.clone();
-    tokio::spawn(async move {
-        // Add an item to be processed and wait for the result.
-        let output = batcher1.add("Key A".to_string(), "Item 1".to_string()).await.unwrap();
+        // Request handler 2
+        let batcher2 = batcher.clone();
+        tokio::spawn(async move {
+            // Add an item to be processed and wait for the result.
+            let output = batcher2
+                .add("Key A".to_string(), "Item 2".to_string())
+                .await
+                .unwrap();
 
-        assert_eq!("Item 1 processed for Key A".to_string(), output);
+            assert_eq!("Item 2 processed for Key A".to_string(), output);
+        });
     });
-
-    // Request handler 2
-    let batcher2 = batcher.clone();
-    tokio::spawn(async move {
-        // Add an item to be processed and wait for the result.
-        let output = batcher2.add("Key A".to_string(), "Item 2".to_string()).await.unwrap();
-
-        assert_eq!("Item 2 processed for Key A".to_string(), output);
-    });
-});
+}
 ```
 
 ## FAQ

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp,
-    fmt::Display,
+    fmt::{Debug, Display},
     mem,
     sync::{
         atomic::{self, AtomicUsize},
@@ -154,7 +154,7 @@ where
 
 impl<K, I, O, E: Display, R> Batch<K, I, O, E, R>
 where
-    K: 'static + Send + Clone,
+    K: 'static + Send + Clone + Debug,
     I: 'static + Send,
     O: 'static + Send,
     E: 'static + Send + Clone + Display,
@@ -178,7 +178,7 @@ where
     /// Acquire resources for this batch, if we are not doing so already.
     ///
     /// Once acquired, a message will be sent to process the batch.
-    pub(crate) fn pre_acquire_resources<F>(&mut self, processor: F, tx: mpsc::Sender<Message<K>>)
+    pub(crate) fn pre_acquire_resources<F>(&mut self, processor: F, tx: mpsc::Sender<Message<K, E>>)
     where
         F: 'static + Send + Processor<K, I, O, E, R>,
     {
@@ -195,11 +195,24 @@ where
 
             let resource_state = Arc::clone(&self.resources);
             tokio::spawn(async move {
-                let span = span!(Level::INFO, "acquire resources");
+                let span = span!(Level::INFO, "acquire resources", batch.key = ?key);
+
                 let resources = processor
                     .acquire_resources(key.clone())
                     .instrument(span.clone())
                     .await;
+
+                let resources = match resources {
+                    Ok(r) => r,
+                    Err(err) => {
+                        if tx.send(Message::Fail(key, generation, err)).await.is_err() {
+                            // The worker must have shut down. In this case, we don't want to process any more
+                            // batches anyway.
+                            debug!("Tried to signal resources acquisition failed but the worker has shut down");
+                        }
+                        return;
+                    }
+                };
 
                 {
                     let mut state = resource_state
@@ -220,7 +233,7 @@ where
         }
     }
 
-    pub(crate) fn process<F>(mut self, processor: F, on_finished: mpsc::Sender<Message<K>>)
+    pub(crate) fn process<F>(mut self, processor: F, on_finished: mpsc::Sender<Message<K, E>>)
     where
         F: 'static + Send + Processor<K, I, O, E, R>,
     {
@@ -230,16 +243,27 @@ where
 
         let batch_size = self.items.len();
         // Convert to u64 so tracing will treat this as an integer instead of a string.
-        let outer_span = span!(Level::INFO, "process batch", batch.size = batch_size as u64);
+        let outer_span = span!(Level::INFO, "process batch", batch.key = ?self.key(), batch.size = batch_size as u64);
 
         // Spawn a new task so we can process multiple batches concurrently, without blocking the
         // run loop.
         tokio::spawn(
             async move {
-                let span = Span::current();
+                let outer_span = Span::current();
 
                 // Replace with a placeholder to keep the Drop impl working.
                 let items = mem::take(&mut self.items);
+
+                let (inputs, txs): (Vec<I>, Vec<SendOutput<O, E>>) = items
+                    .into_iter()
+                    .map(|item| {
+                        // Link the shared batch processing span to the span for each batch item. We
+                        // don't use a parent relationship because that's 1:many (parent:child), and
+                        // this is many:1.
+                        outer_span.follows_from(&item.requesting_span);
+                        (item.input, item.tx)
+                    })
+                    .unzip();
 
                 // Acquire resources (if we don't have them already).
                 let resources = {
@@ -250,80 +274,100 @@ where
                     resources.take()
                 };
                 let resources = match resources {
-                    Some((r, resource_span)) => {
-                        span.follows_from(resource_span);
+                    Some((r, acquire_span)) => {
+                        outer_span.follows_from(acquire_span);
                         r
                     }
                     None => {
-                        let span = span!(Level::INFO, "acquire resources");
+                        let acquire_span =
+                            span!(Level::INFO, "acquire resources", batch.key = ?self.key());
                         let resources = processor
                             .acquire_resources(self.key.clone())
-                            .instrument(span.clone())
+                            .instrument(acquire_span.clone())
                             .await;
-                        resources
+                        match resources {
+                            Ok(r) => r,
+                            Err(err) => {
+                                let outputs: Vec<_> = std::iter::repeat_n(err, batch_size)
+                                    .map(|e| Err(BatchError::ResourceAcquisitionFailed(e)))
+                                    .collect();
+                                self.finalise(txs, outputs, Some(outer_span), on_finished).await;
+                                return;
+                            }
+                        }
                     }
                 };
 
-                let (inputs, txs): (Vec<I>, Vec<SendOutput<O, E>>) = items
-                    .into_iter()
-                    .map(|item| {
-                        // Link the shared batch processing span to the span for each batch item. We
-                        // don't use a parent relationship because that's 1:many (parent:child), and
-                        // this is many:1.
-                        span.follows_from(&item.requesting_span);
-
-                        (item.input, item.tx)
-                    })
-                    .unzip();
+                let inner_span = span!(Level::DEBUG, "process", batch.key = ?self.key(), batch.size = batch_size as u64);
 
                 let result = processor
                     .process(self.key.clone(), inputs.into_iter(), resources)
-                    .instrument(span.clone())
+                    .instrument(inner_span.clone())
                     .await;
 
                 let outputs: Vec<_> = match result {
                     Ok(outputs) => outputs.into_iter().map(|o| Ok(o)).collect(),
                     Err(err) => std::iter::repeat_n(err, batch_size)
-                        .map(|e| Err(e))
+                        .map(|e| Err(BatchError::BatchFailed(e)))
                         .collect(),
                 };
 
-                for (tx, output) in txs.into_iter().zip(outputs) {
-                    if tx
-                        .send((output.map_err(BatchError::BatchFailed), Some(span.clone())))
-                        .is_err()
-                    {
-                        // Whatever was waiting for the output must have shut down. Presumably it
-                        // doesn't care anymore, but we log here anyway. There's not much else we can do
-                        // here.
-                        debug!("Unable to send output over oneshot channel. Receiver deallocated.");
-                    }
-                }
-
-                self.processing.fetch_sub(1, atomic::Ordering::AcqRel);
-
-                // We're finished with this batch
-                if on_finished
-                    .send(Message::Finished(self.key.clone()))
-                    .await
-                    .is_err()
-                {
-                    // The worker must have shut down. In this case, we don't want to process any more
-                    // batches anyway.
-                    debug!("Tried to signal a batch had finished but the worker has shut down");
-                }
+                self.finalise(txs, outputs, Some(outer_span), on_finished).await;
             }
             .instrument(outer_span),
         );
+    }
+
+    pub fn fail(mut self, err: E, on_finished: mpsc::Sender<Message<K, E>>) {
+        let txs: Vec<_> = mem::take(&mut self.items)
+            .into_iter()
+            .map(|item| item.tx)
+            .collect();
+        let outputs = std::iter::repeat_n(err, txs.len())
+            .map(|e| Err(BatchError::ResourceAcquisitionFailed(e)))
+            .collect();
+
+        tokio::spawn(self.finalise(txs, outputs, None, on_finished));
+    }
+
+    /// Send outputs and clean up.
+    async fn finalise(
+        self,
+        txs: Vec<SendOutput<O, E>>,
+        outputs: Vec<Result<O, BatchError<E>>>,
+        span: Option<Span>,
+        on_finished: mpsc::Sender<Message<K, E>>,
+    ) {
+        for (tx, output) in txs.into_iter().zip(outputs) {
+            if tx.send((output, span.clone())).is_err() {
+                // Whatever was waiting for the output must have shut down. Presumably it
+                // doesn't care anymore, but we log here anyway. There's not much else we can do
+                // here.
+                debug!("Unable to send output over oneshot channel. Receiver deallocated.");
+            }
+        }
+
+        self.processing.fetch_sub(1, atomic::Ordering::AcqRel);
+
+        // We're finished with this batch
+        if on_finished
+            .send(Message::Finished(self.key.clone()))
+            .await
+            .is_err()
+        {
+            // The worker must have shut down. In this case, we don't want to process any more
+            // batches anyway.
+            debug!("Tried to signal a batch had finished but the worker has shut down");
+        }
     }
 }
 
 impl<K, I, O, E, R> Batch<K, I, O, E, R>
 where
-    K: 'static + Send + Clone,
-    E: Display,
+    K: 'static + Send + Clone + Debug,
+    E: 'static + Send + Display,
 {
-    pub(crate) fn process_after(&mut self, duration: Duration, tx: mpsc::Sender<Message<K>>) {
+    pub(crate) fn process_after(&mut self, duration: Duration, tx: mpsc::Sender<Message<K, E>>) {
         self.cancel_timeout();
 
         let new_deadline = Instant::now() + duration;

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -121,7 +121,7 @@ impl<K, I, O, E: Display, R> Batch<K, I, O, E, R> {
     pub(crate) fn is_processable(&self) -> bool {
         // To be processable, we must have some items to process...
         self.len() > 0
-            // ... and if there is a timeout deadline, it must be in the past, ...
+            // ... and if there is a timeout deadline, it must be in the past.
             && self
                 .timeout_deadline
                 .is_none_or(|deadline| match deadline.cmp(&Instant::now()){

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -239,7 +239,7 @@ where
                 let span = Span::current();
 
                 // Replace with a placeholder to keep the Drop impl working.
-                let items = mem::replace(&mut self.items, Vec::new());
+                let items = mem::take(&mut self.items);
 
                 // Acquire resources (if we don't have them already).
                 let resources = {
@@ -290,10 +290,7 @@ where
 
                 for (tx, output) in txs.into_iter().zip(outputs) {
                     if tx
-                        .send((
-                            output.map_err(BatchError::BatchFailed),
-                            Some(span.clone()),
-                        ))
+                        .send((output.map_err(BatchError::BatchFailed), Some(span.clone())))
                         .is_err()
                     {
                         // Whatever was waiting for the output must have shut down. Presumably it

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -4,7 +4,7 @@ use std::{
     mem,
     sync::{
         atomic::{self, AtomicUsize},
-        Arc,
+        Arc, Mutex,
     },
     time::Duration,
 };
@@ -16,7 +16,7 @@ use tokio::{
 };
 use tracing::{debug, span, Instrument, Level, Span};
 
-use crate::{batcher::Processor, error::BatchResult, worker::Message, BatchError};
+use crate::{error::BatchResult, processor::Processor, worker::Message, BatchError};
 
 #[derive(Debug)]
 pub(crate) struct BatchItem<K, I, O, E: Display> {
@@ -32,7 +32,7 @@ type SendOutput<O, E> = oneshot::Sender<(BatchResult<O, E>, Option<Span>)>;
 
 /// A batch of items to process.
 #[derive(Debug)]
-pub(crate) struct Batch<K, I, O, E: Display> {
+pub(crate) struct Batch<K, I, O, E: Display, R = ()> {
     key: K,
     generation: Generation,
     items: Vec<BatchItem<K, I, O, E>>,
@@ -42,6 +42,28 @@ pub(crate) struct Batch<K, I, O, E: Display> {
 
     /// The number of batches with this key that are currently processing.
     processing: Arc<AtomicUsize>,
+
+    resources: Arc<Mutex<Resources<R>>>,
+}
+
+#[derive(Debug)]
+enum Resources<R> {
+    NotAcquired,
+    Acquiring,
+    Acquired {
+        resources: R,
+        /// The span in which the resources were acquired.
+        span: Span,
+    },
+}
+
+impl<R> Resources<R> {
+    fn take(&mut self) -> Option<(R, Span)> {
+        match mem::replace(self, Resources::NotAcquired) {
+            Resources::Acquired { resources, span } => Some((resources, span)),
+            Resources::NotAcquired | Resources::Acquiring => None,
+        }
+    }
 }
 
 /// Generations are used to handle the case where a timer goes off after the associated batch has
@@ -55,7 +77,7 @@ impl Generation {
     }
 }
 
-impl<K, I, O, E: Display> Batch<K, I, O, E> {
+impl<K, I, O, E: Display, R> Batch<K, I, O, E, R> {
     pub(crate) fn new(key: K, processing: Arc<AtomicUsize>) -> Self {
         Self {
             key,
@@ -66,6 +88,8 @@ impl<K, I, O, E: Display> Batch<K, I, O, E> {
             timeout_handle: None,
 
             processing,
+
+            resources: Arc::new(Mutex::new(Resources::NotAcquired)),
         }
     }
 
@@ -97,7 +121,7 @@ impl<K, I, O, E: Display> Batch<K, I, O, E> {
     pub(crate) fn is_processable(&self) -> bool {
         // To be processable, we must have some items to process...
         self.len() > 0
-            // ... and if there is a timeout deadline, it must be in the past.
+            // ... and if there is a timeout deadline, it must be in the past, ...
             && self
                 .timeout_deadline
                 .is_none_or(|deadline| match deadline.cmp(&Instant::now()){
@@ -118,7 +142,7 @@ impl<K, I, O, E: Display> Batch<K, I, O, E> {
     }
 }
 
-impl<K, I, O, E: Display> Batch<K, I, O, E>
+impl<K, I, O, E: Display, R> Batch<K, I, O, E, R>
 where
     K: Clone,
 {
@@ -128,12 +152,13 @@ where
     }
 }
 
-impl<K, I, O, E> Batch<K, I, O, E>
+impl<K, I, O, E: Display, R> Batch<K, I, O, E, R>
 where
     K: 'static + Send + Clone,
     I: 'static + Send,
     O: 'static + Send,
     E: 'static + Send + Clone + Display,
+    R: 'static + Send,
 {
     pub(crate) fn new_generation(&self) -> Self {
         Self {
@@ -145,88 +170,163 @@ where
             timeout_handle: None,
 
             processing: self.processing.clone(),
+
+            resources: Arc::new(Mutex::new(Resources::NotAcquired)),
+        }
+    }
+
+    /// Acquire resources for this batch, if we are not doing so already.
+    ///
+    /// Once acquired, a message will be sent to process the batch.
+    pub(crate) fn pre_acquire_resources<F>(&mut self, processor: F, tx: mpsc::Sender<Message<K>>)
+    where
+        F: 'static + Send + Processor<K, I, O, E, R>,
+    {
+        let mut resources = self
+            .resources
+            .lock()
+            .expect("Resources mutex should not be poisoned");
+        if matches!(*resources, Resources::NotAcquired) {
+            *resources = Resources::Acquiring;
+            drop(resources);
+
+            let key = self.key();
+            let generation = self.generation();
+
+            let resource_state = Arc::clone(&self.resources);
+            tokio::spawn(async move {
+                let span = span!(Level::INFO, "acquire resources");
+                let resources = processor
+                    .acquire_resources(key.clone())
+                    .instrument(span.clone())
+                    .await;
+
+                {
+                    let mut state = resource_state
+                        .lock()
+                        .expect("Resources mutex should not be poisoned");
+                    *state = Resources::Acquired { resources, span };
+                    drop(state);
+                }
+
+                if tx.send(Message::Process(key, generation)).await.is_err() {
+                    // The worker must have shut down. In this case, we don't want to process any more
+                    // batches anyway.
+                    debug!(
+                        "Tried to signal resources had been acquired but the worker has shut down"
+                    );
+                }
+            });
         }
     }
 
     pub(crate) fn process<F>(mut self, processor: F, on_finished: mpsc::Sender<Message<K>>)
     where
-        F: 'static + Send + Clone + Processor<K, I, O, E>,
+        F: 'static + Send + Processor<K, I, O, E, R>,
     {
         self.processing.fetch_add(1, atomic::Ordering::AcqRel);
 
         self.cancel_timeout();
 
+        let batch_size = self.items.len();
+        // Convert to u64 so tracing will treat this as an integer instead of a string.
+        let outer_span = span!(Level::INFO, "process batch", batch.size = batch_size as u64);
+
         // Spawn a new task so we can process multiple batches concurrently, without blocking the
         // run loop.
-        tokio::spawn(async move {
-            let batch_size = self.items.len();
+        tokio::spawn(
+            async move {
+                let span = Span::current();
 
-            // Convert to u64 so tracing will treat this as an integer instead of a string.
-            let span = span!(Level::INFO, "process batch", batch_size = batch_size as u64);
+                // Replace with a placeholder to keep the Drop impl working.
+                let items = mem::replace(&mut self.items, Vec::new());
 
-            // Replace with a placeholder to keep the Drop impl working. TODO: is there a better
-            // way?!
-            let mut items = Vec::new();
-            mem::swap(&mut self.items, &mut items);
+                // Acquire resources (if we don't have them already).
+                let resources = {
+                    let mut resources = self
+                        .resources
+                        .lock()
+                        .expect("Resources mutex should not be poisoned");
+                    resources.take()
+                };
+                let resources = match resources {
+                    Some((r, resource_span)) => {
+                        span.follows_from(resource_span);
+                        r
+                    }
+                    None => {
+                        let span = span!(Level::INFO, "acquire resources");
+                        let resources = processor
+                            .acquire_resources(self.key.clone())
+                            .instrument(span.clone())
+                            .await;
+                        resources
+                    }
+                };
 
-            let (inputs, txs): (Vec<I>, Vec<SendOutput<O, E>>) = items
-                .into_iter()
-                .map(|item| {
-                    // Link the shared batch processing span to the span for each batch item. We
-                    // don't use a parent relationship because that's 1:many (parent:child), and
-                    // this is many:1.
-                    span.follows_from(item.requesting_span.id());
+                let (inputs, txs): (Vec<I>, Vec<SendOutput<O, E>>) = items
+                    .into_iter()
+                    .map(|item| {
+                        // Link the shared batch processing span to the span for each batch item. We
+                        // don't use a parent relationship because that's 1:many (parent:child), and
+                        // this is many:1.
+                        span.follows_from(&item.requesting_span);
 
-                    (item.input, item.tx)
-                })
-                .unzip();
+                        (item.input, item.tx)
+                    })
+                    .unzip();
 
-            let result = processor
-                .process(self.key.clone(), inputs.into_iter())
-                .instrument(span.clone())
-                .await;
+                let result = processor
+                    .process(self.key.clone(), inputs.into_iter(), resources)
+                    .instrument(span.clone())
+                    .await;
 
-            let outputs: Vec<_> = match result {
-                Ok(outputs) => outputs.into_iter().map(|o| Ok(o)).collect(),
-                Err(err) => std::iter::repeat_n(err, batch_size)
-                    .map(|e| Err(e))
-                    .collect(),
-            };
+                let outputs: Vec<_> = match result {
+                    Ok(outputs) => outputs.into_iter().map(|o| Ok(o)).collect(),
+                    Err(err) => std::iter::repeat_n(err, batch_size)
+                        .map(|e| Err(e))
+                        .collect(),
+                };
 
-            for (tx, output) in txs.into_iter().zip(outputs) {
-                if tx
-                    .send((output.map_err(BatchError::BatchFailed), Some(span.clone())))
+                for (tx, output) in txs.into_iter().zip(outputs) {
+                    if tx
+                        .send((
+                            output.map_err(BatchError::BatchFailed),
+                            Some(span.clone()),
+                        ))
+                        .is_err()
+                    {
+                        // Whatever was waiting for the output must have shut down. Presumably it
+                        // doesn't care anymore, but we log here anyway. There's not much else we can do
+                        // here.
+                        debug!("Unable to send output over oneshot channel. Receiver deallocated.");
+                    }
+                }
+
+                self.processing.fetch_sub(1, atomic::Ordering::AcqRel);
+
+                // We're finished with this batch
+                if on_finished
+                    .send(Message::Finished(self.key.clone()))
+                    .await
                     .is_err()
                 {
-                    // Whatever was waiting for the output must have shut down. Presumably it
-                    // doesn't care anymore, but we log here anyway. There's not much else we can do
-                    // here.
-                    debug!("Unable to send output over oneshot channel. Receiver deallocated.");
+                    // The worker must have shut down. In this case, we don't want to process any more
+                    // batches anyway.
+                    debug!("Tried to signal a batch had finished but the worker has shut down");
                 }
             }
-
-            self.processing.fetch_sub(1, atomic::Ordering::AcqRel);
-
-            // We're finished with this batch
-            if on_finished
-                .send(Message::Finished(self.key.clone()))
-                .await
-                .is_err()
-            {
-                // The worker must have shut down. In this case, we don't want to process any more
-                // batches anyway.
-                debug!("Tried to signal a batch had finished but the worker has shut down");
-            }
-        });
+            .instrument(outer_span),
+        );
     }
 }
 
-impl<K, I, O, E> Batch<K, I, O, E>
+impl<K, I, O, E, R> Batch<K, I, O, E, R>
 where
     K: 'static + Send + Clone,
     E: Display,
 {
-    pub(crate) fn time_out_after(&mut self, duration: Duration, tx: mpsc::Sender<Message<K>>) {
+    pub(crate) fn process_after(&mut self, duration: Duration, tx: mpsc::Sender<Message<K>>) {
         self.cancel_timeout();
 
         let new_deadline = Instant::now() + duration;
@@ -249,7 +349,7 @@ where
     }
 }
 
-impl<K, I, O, E: Display> Drop for Batch<K, I, O, E> {
+impl<K, I, O, E: Display, R> Drop for Batch<K, I, O, E, R> {
     fn drop(&mut self) {
         if let Some(handle) = self.timeout_handle.take() {
             handle.abort();
@@ -286,7 +386,7 @@ mod tests {
         });
 
         let (tx, _rx) = mpsc::channel(1);
-        batch.time_out_after(Duration::from_millis(50), tx);
+        batch.process_after(Duration::from_millis(50), tx);
 
         assert!(
             !batch.is_processable(),

--- a/src/batch_queue.rs
+++ b/src/batch_queue.rs
@@ -89,7 +89,7 @@ where
     }
 
     pub(crate) fn take_next_batch(&mut self) -> Option<Batch<K, I, O, E, R>> {
-        let batch = self.queue.front_mut().expect("Should always be non-empty");
+        let batch = self.queue.front().expect("Should always be non-empty");
         if batch.is_processable() {
             let batch = self.queue.pop_front().expect("Should always be non-empty");
             if self.queue.is_empty() {

--- a/src/batch_queue.rs
+++ b/src/batch_queue.rs
@@ -9,13 +9,14 @@ use tokio::sync::mpsc;
 
 use crate::{
     batch::{Batch, BatchItem, Generation},
+    processor::Processor,
     worker::Message,
     Limits,
 };
 
 /// A double-ended queue for queueing up multiple batches for later processing.
-pub(crate) struct BatchQueue<K, I, O, E: Display> {
-    queue: VecDeque<Batch<K, I, O, E>>,
+pub(crate) struct BatchQueue<K, I, O, E: Display, R = ()> {
+    queue: VecDeque<Batch<K, I, O, E, R>>,
 
     limits: Limits,
 
@@ -23,7 +24,7 @@ pub(crate) struct BatchQueue<K, I, O, E: Display> {
     processing: Arc<AtomicUsize>,
 }
 
-impl<K, I, O, E: Display> BatchQueue<K, I, O, E> {
+impl<K, I, O, E: Display, R> BatchQueue<K, I, O, E, R> {
     pub(crate) fn new(key: K, limits: Limits) -> Self {
         // The queue size is the same as the max processing capacity.
         let mut queue = VecDeque::with_capacity(limits.max_key_concurrency);
@@ -59,18 +60,21 @@ impl<K, I, O, E: Display> BatchQueue<K, I, O, E> {
         back.is_new_batch()
     }
 
+    /// Are we currently processing the maximum number of batches for this key (according to
+    /// the `Limits`)?
     pub(crate) fn at_max_processing_capacity(&self) -> bool {
         self.processing.load(std::sync::atomic::Ordering::Acquire)
             >= self.limits.max_key_concurrency
     }
 }
 
-impl<K, I, O, E> BatchQueue<K, I, O, E>
+impl<K, I, O, E, R> BatchQueue<K, I, O, E, R>
 where
     K: 'static + Send + Clone,
     I: 'static + Send,
     O: 'static + Send,
     E: 'static + Send + Clone + Display,
+    R: 'static + Send,
 {
     pub(crate) fn push(&mut self, item: BatchItem<K, I, O, E>) {
         let back = self.queue.back_mut().expect("Should always be non-empty");
@@ -84,8 +88,12 @@ where
         }
     }
 
-    pub(crate) fn take_next_batch(&mut self) -> Option<Batch<K, I, O, E>> {
-        let batch = self.queue.front().expect("Should always be non-empty");
+    fn next_batch_mut(&mut self) -> &mut Batch<K, I, O, E, R> {
+        self.queue.front_mut().expect("Should always be non-empty")
+    }
+
+    pub(crate) fn take_next_batch(&mut self) -> Option<Batch<K, I, O, E, R>> {
+        let batch = self.next_batch_mut();
         if batch.is_processable() {
             let batch = self.queue.pop_front().expect("Should always be non-empty");
             if self.queue.is_empty() {
@@ -97,7 +105,10 @@ where
         None
     }
 
-    pub(crate) fn take_generation(&mut self, generation: Generation) -> Option<Batch<K, I, O, E>> {
+    pub(crate) fn take_generation(
+        &mut self,
+        generation: Generation,
+    ) -> Option<Batch<K, I, O, E, R>> {
         for (index, batch) in self.queue.iter().enumerate() {
             if batch.is_generation(generation) {
                 if batch.is_processable() {
@@ -119,15 +130,24 @@ where
 
         None
     }
+
+    /// Acquire resources ahead of processing for the next batch.
+    pub(crate) fn pre_acquire_resources<F>(&mut self, processor: F, tx: mpsc::Sender<Message<K>>)
+    where
+        F: 'static + Send + Processor<K, I, O, E, R>,
+    {
+        let batch = self.next_batch_mut();
+        batch.pre_acquire_resources(processor, tx);
+    }
 }
 
-impl<K, I, O, E> BatchQueue<K, I, O, E>
+impl<K, I, O, E, R> BatchQueue<K, I, O, E, R>
 where
     K: 'static + Send + Clone,
     E: Display,
 {
-    pub(crate) fn time_out_after(&mut self, duration: Duration, tx: mpsc::Sender<Message<K>>) {
+    pub(crate) fn process_after(&mut self, duration: Duration, tx: mpsc::Sender<Message<K>>) {
         let back = self.queue.back_mut().expect("Should always be non-empty");
-        back.time_out_after(duration, tx);
+        back.process_after(duration, tx);
     }
 }

--- a/src/batcher.rs
+++ b/src/batcher.rs
@@ -1,4 +1,9 @@
-use std::{fmt::Display, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+    marker::PhantomData,
+    sync::Arc,
+};
 
 use tokio::sync::{mpsc, oneshot};
 use tracing::{span, Level, Span};
@@ -35,10 +40,10 @@ where
 
 impl<K, I, O, E, R> Batcher<K, I, O, E, R>
 where
-    K: 'static + Send + Eq + Hash + Clone,
+    K: 'static + Send + Eq + Hash + Clone + Debug,
     I: 'static + Send,
     O: 'static + Send,
-    E: 'static + Send + Clone + Display,
+    E: 'static + Send + Clone + Display + Debug,
     R: 'static + Send,
 {
     /// Create a new batcher.

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,10 @@ pub enum BatchError<E: Display> {
     /// Something went wrong while processing a batch.
     #[error("The entire batch failed: {}", .0)]
     BatchFailed(E),
+
+    /// Something went wrong while acquiring resources for processing.
+    #[error("Resource acquisition failed: {}", .0)]
+    ResourceAcquisitionFailed(E),
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@ mod tests {
     pub struct SimpleBatchProcessor(pub Duration);
 
     impl Processor<String, String, String> for SimpleBatchProcessor {
-        async fn acquire_resources(&self, _key: String) -> () {
-            ()
+        async fn acquire_resources(&self, _key: String) -> Result<(), String> {
+            Ok(())
         }
 
         async fn process(

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -67,7 +67,8 @@ pub enum OnFull {
     Reject,
 }
 
-pub enum PreAdd {
+#[derive(Debug)]
+pub(crate) enum PreAdd {
     AddAndProcess,
     AddAndAcquireResources,
     AddAndProcessAfter(Duration),
@@ -75,7 +76,7 @@ pub enum PreAdd {
     Add,
 }
 
-pub enum PostFinish {
+pub(crate) enum PostFinish {
     Process,
     DoNothing,
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,0 +1,46 @@
+use std::{fmt::Display, future::Future};
+
+/// Process a batch of inputs for a given key.
+///
+/// Should be cheap to clone.
+pub trait Processor<K, I, O = (), E = String, R = ()>
+where
+    E: Display,
+{
+    /// Acquire resources to be used for processing the next batch with the given key.
+    ///
+    /// This method is called before processing each batch.
+    ///
+    /// For `BatchingPolicy::Immediate`, the batch will keep accumulating items until the resources
+    /// are acquired.
+    ///
+    /// Can be used to e.g. acquire a database connection from a pool.
+    fn acquire_resources(&self, key: K) -> impl Future<Output = R> + Send;
+
+    /// Process the batch.
+    ///
+    /// The order of the outputs in the returned `Vec` must be the same as the order of the inputs
+    /// in the given iterator.
+    fn process(
+        &self,
+        key: K,
+        inputs: impl Iterator<Item = I> + Send,
+        resources: R,
+    ) -> impl Future<Output = Result<Vec<O>, E>> + Send;
+}
+
+// pub trait ResourceAcquirer<K, E = String, R = ()>
+// where
+//     E: Display,
+// {
+//     /// Acquire resources to be used for processing a batch.
+//     ///
+//     /// This method is called before processing each batch. It should return the resources to be
+//     /// used for processing the batch.
+//     ///
+//     /// For `BatchingPolicy::Immediate`, the batch will keep accumulating items until the resources
+//     /// are acquired.
+//     ///
+//     /// Useful for e.g. acquiring a database connection from a pool.
+//     fn acquire_resources(&self, key: K) -> impl Future<Output = Result<R, E>> + Send;
+// }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -15,7 +15,7 @@ where
     /// are acquired.
     ///
     /// Can be used to e.g. acquire a database connection from a pool.
-    fn acquire_resources(&self, key: K) -> impl Future<Output = R> + Send;
+    fn acquire_resources(&self, key: K) -> impl Future<Output = Result<R, E>> + Send;
 
     /// Process the batch.
     ///

--- a/tests/resources/mod.rs
+++ b/tests/resources/mod.rs
@@ -1,0 +1,110 @@
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use batch_aint_one::{Batcher, BatchingPolicy, Limits, Processor};
+use futures::{future::join_all, lock::Mutex};
+
+#[derive(Debug, Clone)]
+pub struct ResourceAcquiringProcessor {
+    acquisition_dur: Duration,
+    processing_dur: Duration,
+
+    resource_count: Arc<AtomicUsize>,
+    batches: Arc<Mutex<HashMap<String, Vec<usize>>>>,
+}
+
+impl ResourceAcquiringProcessor {
+    pub fn new(acquisition_dur: Duration, processing_dur: Duration) -> Self {
+        Self {
+            acquisition_dur,
+            processing_dur,
+            resource_count: Arc::new(AtomicUsize::new(0)),
+            batches: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Processor<String, String, String, String, String> for ResourceAcquiringProcessor {
+    async fn acquire_resources(&self, key: String) -> String {
+        tokio::time::sleep(self.acquisition_dur).await;
+        let count = self.resource_count.fetch_add(1, Ordering::SeqCst);
+        key + "_" + &count.to_string()
+    }
+
+    async fn process(
+        &self,
+        key: String,
+        inputs: impl Iterator<Item = String> + Send,
+        resources: String,
+    ) -> Result<Vec<String>, String> {
+        tokio::time::sleep(self.processing_dur).await;
+
+        let outputs: Vec<String> = inputs
+            .map(|s| {
+                "Item ".to_string()
+                    + &s
+                    + " processed for "
+                    + &key
+                    + " with resources "
+                    + &resources
+            })
+            .collect();
+
+        let mut batches = self.batches.lock().await;
+        batches.entry(key.clone()).or_default().push(outputs.len());
+
+        Ok(outputs)
+    }
+}
+
+/// Given we acquire resources before processing
+/// When we use an Immediate batching strategy
+/// Then items should continue to be added to the batch while resources are being acquired
+#[tokio::test]
+async fn strategy_duration() {
+    tokio::time::pause();
+
+    let acquisition_dur = Duration::from_millis(100);
+    let processing_dur = Duration::from_millis(5);
+
+    let processor = ResourceAcquiringProcessor::new(acquisition_dur, processing_dur);
+
+    let batcher = Batcher::new(
+        processor.clone(),
+        Limits::default().max_batch_size(10).max_key_concurrency(2),
+        BatchingPolicy::Immediate,
+    );
+
+    let handler = |i: i32| {
+        let f = batcher.add("key".to_string(), i.to_string());
+        async move { f.await.unwrap() }
+    };
+
+    let mut tasks = vec![];
+    for i in 1..=20 {
+        tasks.push(tokio_test::task::spawn(handler(i)));
+    }
+
+    let outputs = join_all(tasks.into_iter()).await;
+
+    assert_eq!(
+        outputs.first().unwrap(),
+        "Item 1 processed for key with resources key_0"
+    );
+    assert_eq!(
+        outputs.last().unwrap(),
+        "Item 20 processed for key with resources key_1"
+    );
+
+    let batches = processor.batches.lock().await;
+    let batch_sizes = batches.get("key").unwrap();
+    assert_eq!(batch_sizes.len(), 2);
+    assert_eq!(batch_sizes[0], 10);
+    assert_eq!(batch_sizes[1], 10);
+}

--- a/tests/resources/mod.rs
+++ b/tests/resources/mod.rs
@@ -7,11 +7,14 @@ use std::{
     time::Duration,
 };
 
-use batch_aint_one::{Batcher, BatchingPolicy, Limits, Processor};
+use assert_matches::assert_matches;
+use batch_aint_one::{BatchError, Batcher, BatchingPolicy, Limits, Processor};
 use futures::{future::join_all, lock::Mutex};
 
 #[derive(Debug, Clone)]
 pub struct ResourceAcquiringProcessor {
+    fail: bool,
+
     acquisition_dur: Duration,
     processing_dur: Duration,
 
@@ -20,21 +23,34 @@ pub struct ResourceAcquiringProcessor {
 }
 
 impl ResourceAcquiringProcessor {
-    pub fn new(acquisition_dur: Duration, processing_dur: Duration) -> Self {
+    fn new(acquisition_dur: Duration, processing_dur: Duration) -> Self {
         Self {
+            fail: false,
+
             acquisition_dur,
             processing_dur,
             resource_count: Arc::new(AtomicUsize::new(0)),
             batches: Arc::new(Mutex::new(HashMap::new())),
         }
     }
+
+    fn with_failure(mut self) -> Self {
+        self.fail = true;
+        self
+    }
 }
 
 impl Processor<String, String, String, String, String> for ResourceAcquiringProcessor {
-    async fn acquire_resources(&self, key: String) -> String {
+    async fn acquire_resources(&self, key: String) -> Result<String, String> {
         tokio::time::sleep(self.acquisition_dur).await;
         let count = self.resource_count.fetch_add(1, Ordering::SeqCst);
-        key + "_" + &count.to_string()
+        if self.fail {
+            return Err("Failed to acquire resources - ".to_string()
+                + &key
+                + "_"
+                + &count.to_string());
+        }
+        Ok(key + "_" + &count.to_string())
     }
 
     async fn process(
@@ -67,7 +83,7 @@ impl Processor<String, String, String, String, String> for ResourceAcquiringProc
 /// When we use an Immediate batching strategy
 /// Then items should continue to be added to the batch while resources are being acquired
 #[tokio::test]
-async fn strategy_duration() {
+async fn immediate_batches_while_acquiring() {
     tokio::time::pause();
 
     let acquisition_dur = Duration::from_millis(100);
@@ -107,4 +123,45 @@ async fn strategy_duration() {
     assert_eq!(batch_sizes.len(), 2);
     assert_eq!(batch_sizes[0], 10);
     assert_eq!(batch_sizes[1], 10);
+}
+
+#[tokio::test]
+async fn immediate_when_acquisition_fails() {
+    tokio::time::pause();
+
+    let acquisition_dur = Duration::from_millis(100);
+    let processing_dur = Duration::from_millis(5);
+
+    let processor = ResourceAcquiringProcessor::new(acquisition_dur, processing_dur).with_failure();
+
+    let batcher = Batcher::new(
+        processor.clone(),
+        Limits::default().max_batch_size(10).max_key_concurrency(2),
+        BatchingPolicy::Immediate,
+    );
+
+    let handler = |i: i32| {
+        let f = batcher.add("key".to_string(), i.to_string());
+        async move { f.await }
+    };
+
+    let mut tasks = vec![];
+    for i in 1..=20 {
+        tasks.push(tokio_test::task::spawn(handler(i)));
+    }
+
+    let outputs = join_all(tasks.into_iter()).await;
+
+    assert_matches!(
+        outputs.first(),
+        Some(Err(BatchError::ResourceAcquisitionFailed(s))) => {
+            assert_eq!(s, "Failed to acquire resources - key_0");
+        }
+    );
+    assert_matches!(
+        outputs.last(),
+        Some(Err(BatchError::ResourceAcquisitionFailed(s))) => {
+            assert_eq!(s, "Failed to acquire resources - key_1");
+        }
+    );
 }

--- a/tests/strategies/duration.rs
+++ b/tests/strategies/duration.rs
@@ -10,7 +10,7 @@ use crate::{assert_elapsed, types::SimpleBatchProcessor};
 /// When we process one item
 /// Then it should take as long as the batching duration + the processing duration
 #[tokio::test]
-async fn strategy_duration() {
+async fn total_duration() {
     tokio::time::pause();
 
     let processing_dur = Duration::from_millis(30);
@@ -44,7 +44,7 @@ async fn strategy_duration() {
 ///  And we process when full
 /// Then they should all succeed
 #[tokio::test]
-async fn strategy_duration_loaded_process_on_full() {
+async fn loaded_process_on_full() {
     tokio::time::pause();
 
     let processing_dur = Duration::from_millis(50);
@@ -75,7 +75,7 @@ async fn strategy_duration_loaded_process_on_full() {
 ///  And we reject when full
 /// Then only one batch should succeed, the rest should get rejected
 #[tokio::test]
-async fn strategy_duration_loaded_reject_on_full() {
+async fn loaded_reject_on_full() {
     tokio::time::pause();
 
     let processing_dur = Duration::from_millis(50);

--- a/tests/strategies/immediate.rs
+++ b/tests/strategies/immediate.rs
@@ -1,16 +1,16 @@
 use std::time::Duration;
 
 use batch_aint_one::{Batcher, BatchingPolicy, Limits};
-use futures::future::join_all;
+use futures::{future::join_all, FutureExt};
 use tokio::{join, time::Instant};
 
 use crate::{assert_duration, types::SimpleBatchProcessor};
 
-/// Given we use a Sequential strategy with max concurrency = 1
+/// Given we use a Immediate strategy with max concurrency = 1
 /// When we process two items
 /// Then it should process them serially, i.e. it should take twice the processing duration
 #[tokio::test]
-async fn strategy_sequential_single_concurrency() {
+async fn single_concurrency() {
     tokio::time::pause();
 
     let processing_dur = Duration::from_millis(50);
@@ -30,7 +30,11 @@ async fn strategy_sequential_single_concurrency() {
     };
 
     let h1 = tokio_test::task::spawn(handler());
-    let h2 = tokio_test::task::spawn(handler());
+
+    // Sleep a bit to ensure the first batch acquires resources and starts processing before the
+    // second item gets submitted
+    let h2 =
+        tokio_test::task::spawn(tokio::time::sleep(Duration::from_millis(1)).then(|_| handler()));
 
     let (dur1, dur2) = join!(h1, h2);
 
@@ -41,11 +45,11 @@ async fn strategy_sequential_single_concurrency() {
     assert_duration!(d, processing_dur * 2, std::time::Duration::from_millis(2));
 }
 
-/// Given we use a Sequential strategy with max concurrency = 2
+/// Given we use a Immediate strategy with max concurrency = 2
 /// When we process two items
 /// Then it should process them concurrently
 #[tokio::test]
-async fn strategy_sequential_dual() {
+async fn dual() {
     tokio::time::pause();
 
     let processing_dur = Duration::from_millis(50);
@@ -65,7 +69,11 @@ async fn strategy_sequential_dual() {
     };
 
     let h1 = tokio_test::task::spawn(handler());
-    let h2 = tokio_test::task::spawn(handler());
+
+    // Sleep a bit to ensure the first batch acquires resources and starts processing before the
+    // second item gets submitted
+    let h2 =
+        tokio_test::task::spawn(tokio::time::sleep(Duration::from_millis(1)).then(|_| handler()));
 
     let (dur1, dur2) = join!(h1, h2);
 
@@ -76,13 +84,13 @@ async fn strategy_sequential_dual() {
     assert_duration!(d, processing_dur, std::time::Duration::from_millis(2));
 }
 
-/// Given we use a Sequential strategy with max concurrency = 1
+/// Given we use a Immediate strategy with max concurrency = 1
 /// When we process the first item
 ///  And wait for it to complete
 ///  And then add another item
 /// Then it should succeed
 #[tokio::test]
-async fn strategy_sequential_single_concurrency_with_wait() {
+async fn single_concurrency_with_wait() {
     tokio::time::pause();
 
     let processing_dur = Duration::from_millis(50);
@@ -108,11 +116,11 @@ async fn strategy_sequential_single_concurrency_with_wait() {
     assert_duration!(d1, processing_dur, std::time::Duration::from_millis(2));
 }
 
-/// Given we use a Sequential strategy with max concurrency = 1
+/// Given we use a Immediate strategy with max concurrency = 1
 /// When we submit the maximum size + 1 at once (first batch of 1, then a full batch)
 /// Then they should all succeed
 #[tokio::test]
-async fn strategy_sequential_single_concurrency_full() {
+async fn single_concurrency_full() {
     tokio::time::pause();
 
     let processing_dur = Duration::from_millis(50);
@@ -138,14 +146,14 @@ async fn strategy_sequential_single_concurrency_full() {
     assert_eq!(outputs.last().unwrap(), "101 processed for key");
 }
 
-/// Given we use a Sequential strategy with max concurrency = 1
+/// Given we use a Immediate strategy with max concurrency = 1
 /// When we submit > the maximum size + 1 at once
 /// Then they should all succeed except one
 #[tokio::test]
-async fn strategy_sequential_single_concurrency_reject() {
+async fn single_concurrency_reject() {
     tokio::time::pause();
 
-    let processing_dur = Duration::from_millis(50);
+    let processing_dur = Duration::from_millis(500);
 
     let batcher = Batcher::new(
         SimpleBatchProcessor(processing_dur),
@@ -153,14 +161,16 @@ async fn strategy_sequential_single_concurrency_reject() {
         BatchingPolicy::Immediate,
     );
 
-    let handler = |i: i32| {
+    let handler = |i: u64| {
         let f = batcher.add("key".to_string(), i.to_string());
         f
     };
 
     let mut tasks = vec![];
     for i in 1..=102 {
-        tasks.push(tokio_test::task::spawn(handler(i)));
+        tasks.push(tokio_test::task::spawn(
+            tokio::time::sleep(Duration::from_millis(i)).then(move |_| handler(i)),
+        ));
     }
 
     let outputs = join_all(tasks.into_iter()).await;
@@ -171,11 +181,11 @@ async fn strategy_sequential_single_concurrency_reject() {
     assert_eq!(err.len(), 1);
 }
 
-/// Given we use a Sequential strategy with max concurrency = 2
+/// Given we use a Immediate strategy with max concurrency = 2
 /// When we submit 2 * maximum_size + 1 at once (first batch of 1, then two full batches)
 /// Then they should all succeed
 #[tokio::test]
-async fn strategy_sequential_double_concurrency_full() {
+async fn double_concurrency_full() {
     tokio::time::pause();
 
     let processing_dur = Duration::from_millis(50);

--- a/tests/strategies/mod.rs
+++ b/tests/strategies/mod.rs
@@ -1,3 +1,3 @@
 mod duration;
-mod sequential;
+mod immediate;
 mod size;

--- a/tests/strategies/size.rs
+++ b/tests/strategies/size.rs
@@ -6,8 +6,11 @@ use tokio::join;
 
 use crate::types::SimpleBatchProcessor;
 
+/// Given we use a Size strategy
+/// When we submit exactly one batch worth of items
+/// Then it should process them all immediately
 #[tokio::test]
-async fn strategy_size() {
+async fn process_when_full() {
     let batcher = Batcher::new(
         SimpleBatchProcessor(Duration::ZERO),
         Limits::default().max_batch_size(3),
@@ -29,7 +32,7 @@ async fn strategy_size() {
 /// When we submit several batches worth of items at once
 /// Then they should all succeed
 #[tokio::test]
-async fn strategy_size_loaded() {
+async fn loaded() {
     tokio::time::pause();
 
     let processing_dur = Duration::from_millis(50);
@@ -56,7 +59,7 @@ async fn strategy_size_loaded() {
 }
 
 #[tokio::test]
-async fn strategy_size_max_concurrency_limit() {
+async fn max_concurrency_limit() {
     let batcher = Batcher::new(
         SimpleBatchProcessor(Duration::ZERO),
         Limits::default().max_batch_size(1).max_key_concurrency(2),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,4 @@
+mod resources;
 mod strategies;
 mod types;
 

--- a/tests/types/mod.rs
+++ b/tests/types/mod.rs
@@ -6,8 +6,8 @@ use batch_aint_one::{Batcher, Processor};
 pub struct SimpleBatchProcessor(pub Duration);
 
 impl Processor<String, String, String> for SimpleBatchProcessor {
-    async fn acquire_resources(&self, _key: String) -> () {
-        ()
+    async fn acquire_resources(&self, _key: String) -> Result<(), String> {
+        Ok(())
     }
 
     async fn process(

--- a/tests/types/mod.rs
+++ b/tests/types/mod.rs
@@ -6,10 +6,15 @@ use batch_aint_one::{Batcher, Processor};
 pub struct SimpleBatchProcessor(pub Duration);
 
 impl Processor<String, String, String> for SimpleBatchProcessor {
+    async fn acquire_resources(&self, _key: String) -> () {
+        ()
+    }
+
     async fn process(
         &self,
         key: String,
         inputs: impl Iterator<Item = String> + Send,
+        _resources: (),
     ) -> Result<Vec<String>, String> {
         tokio::time::sleep(self.0).await;
         Ok(inputs.map(|s| s + " processed for " + &key).collect())


### PR DESCRIPTION
## Problem

**Use case: Batching database inserts.**

Scenario: A spike of requests arrive.

Configuration:

- Max. concurrency = 10 (can use up to 10 connections)
- Strategy = Immediate

_Initial state: One database connection available. No batches in progress._

1. First item submitted – immediately starts processing, acquires only connection.
2. Second item submitted – immediately starts processing, starts acquiring a new connection (slow).
3. 3-10th items submitted – same again, etc. until we run out of connections
4. Then new items start getting batched up

We end up trying to create 9 connections concurrently, which can be a significant load (especially with higher numbers).

Effectively, this strategy maximises concurrency by using more connections instead of larger batches, which can be wasteful. This is intended, but can create unnecessary resources when resource acquisition is slow relative to processing time, e.g. >100ms to create a connection vs 1-2ms to insert an item.

The higher the configured maximum concurrency, and the slower the resource acquisition, the worse the issue.

## Solution

Add a _resource acquisition step_.

For non-Immediate strategies, this has little effect. 

For Immediate, we kick off the resource acquisition immediately and carry on batching items until the resources are ready.

The above scenario would therefore become:

1. First item submitted – immediately acquires a connection, starts processing.
2. Second item submitted – starts opening a new connection
3. Third item submitted – gets added to the current batch
4. ... etc. until the connection is opened and then the full batch starts processing

